### PR TITLE
fix(CARE-VL): Add overwrite_config for vocab_size compatibility

### DIFF
--- a/CARE-VL/inference_vlm.py
+++ b/CARE-VL/inference_vlm.py
@@ -116,8 +116,14 @@ def main():
     device_map = "auto"
 
     print(f"Loading model from: {args.model_path}")
+    overwrite_config = {
+        "tie_word_embeddings": False,
+        "use_cache": True,
+        "vocab_size": 152064,
+    }
     tokenizer, model, image_processor, max_length = load_pretrained_model(
-        args.model_path, None, model_name, device_map=device_map, attn_implementation="sdpa"
+        args.model_path, None, model_name, device_map=device_map,
+        attn_implementation="sdpa", overwrite_config=overwrite_config
     )
     model.eval()
 


### PR DESCRIPTION
- Add overwrite_config with vocab_size=152064 to load_pretrained_model
- Required for transformers version compatibility (weight has 152064 vocab but config.json doesn't specify vocab_size, causing shape mismatch)